### PR TITLE
fix issue with off command

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -31,6 +31,6 @@ class WIFISocket(ActorBase):
         self.send(self.onCommand)
 
     def off(self):
-        self.send(self.onCommand)
+        self.send(self.offCommand)
 
 


### PR DESCRIPTION
Typo in off function meant the on command was always being sent.  Corrected to send off command instead.